### PR TITLE
temp fix now that tensorflow 2 is out

### DIFF
--- a/full_requirements.txt
+++ b/full_requirements.txt
@@ -1,5 +1,5 @@
-tensorflow
-tensorflow-hub
+tensorflow<2.0.0
+tensorflow-hub<2.0.0
 Pillow
 nltk
 libsixel-python


### PR DESCRIPTION
`pip install -r full_requirements.txt` will install tensorflow 2.0, which isn't compatible with the conversion script